### PR TITLE
fix pname output by using ps with pid

### DIFF
--- a/helpers/bashscripts/activewindow
+++ b/helpers/bashscripts/activewindow
@@ -32,7 +32,7 @@ case "$1" in
 
             pname)
                 if [ -f "$VARDIR/pname.txt" ]; then
-                    echo "$(cat "$VARDIR/pname.txt")";
+                    ps -p "$(cat "$VARDIR/pid.txt")" -o comm=
                 else
                     echo "(unknown)";
                 fi


### PR DESCRIPTION
It looks like the [kwin api](https://develop.kde.org/docs/plasma/kwin/api/) does not have a way to get the process name unless I'm overlooking it and it seems the pname option was never fully implemented. This should have it functional, this does add a new dependency on `ps` but I don't know of a system that is missing it. 

resolves #3 